### PR TITLE
fix #16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ dub.selections.json
 examples/s3/test-aws-s3
 
 *.sublime-project
+
+untitled.sublime-workspace
+
+vibe-s3-test-library


### PR DESCRIPTION
As was said in slack all Exception API is already implemented.
AWSExceptino.type is Error Code that can be used by kafka2s3-d. This PR
only add logging and catches exception from `abortMultipartUpload .